### PR TITLE
Allow symfony/finder ^5.0

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -13,7 +13,7 @@
     "php": "^7.1",
     "spiral/core": "^1.0",
     "spiral/logger": "^1.0",
-    "symfony/finder": "^4.1"
+    "symfony/finder": "^4.1|^5.0"
   },
   "require-dev": {
     "phpunit/phpunit": "~7.0",


### PR DESCRIPTION
Allow symfony/finder ^5.0 in require section for compatibility with Symfony 5